### PR TITLE
Update power_profile.xml

### DIFF
--- a/overlay/frameworks/base/core/res/res/xml/power_profile.xml
+++ b/overlay/frameworks/base/core/res/res/xml/power_profile.xml
@@ -87,7 +87,7 @@
         <value>4</value>
     </array>
     <item name="cpu.awake">40.36</item>
-    <item name="battery.capacity">2930</item>
+    <item name="battery.capacity">6000</item>
     <array name="wifi.batchedscan">
         <value>.0002</value>
         <value>.002</value>


### PR DESCRIPTION
The correct battery capacity is 6000, not 2930 mAh. This is the power_profile from 'ivy' (Z3+ Tablet, a.k.a. Z4 Tablet in Japan), not karin or karin_windy.

I've found the correct file: https://github.com/sonyxperiadev/device-sony-karin_windy/blob/master/overlay/frameworks/base/core/res/res/xml/power_profile.xml